### PR TITLE
Region prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ from a non-default feed (such as "adfree"):
 "uri": "/<podcast_id>/<feed_id>/<episode_guid>/<arrangement_digest>/filename.mp3"
 ```
 
-AND the `uri` may also also optionally include an `<aws_region>` token, to indicate
-which region the Dovetail Router redirect originated from. This will tie the
-CloudFront behavior + realtime-logs to that region, for analytics processing.
+AND the `uri` may also also optionally start with an `<behavior_prefix>` token,
+to indicate which "stack" the Dovetail Router redirect originated from. This
+will tie the CloudFront behavior + realtime-logs to that specific dovetail
+stack within a region, for analytics processing. This token must start with a
+lowercase character, not a number.
 
 The `exp` is a (currently optional) epoch seconds timestamp, when this url will
 no longer be valid and must be redirected back for a newer arrangement.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ from a non-default feed (such as "adfree"):
 "uri": "/<podcast_id>/<feed_id>/<episode_guid>/<arrangement_digest>/filename.mp3"
 ```
 
+AND the `uri` may also also optionally include an `<aws_region>` token, to indicate
+which region the Dovetail Router redirect originated from. This will tie the
+CloudFront behavior + realtime-logs to that region, for analytics processing.
+
 The `exp` is a (currently optional) epoch seconds timestamp, when this url will
 no longer be valid and must be redirected back for a newer arrangement.
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,14 @@ function handler(event) {
     var now = Math.round(Date.now() / 1000);
     if (now > parseInt(querystring.exp.value, 10)) {
       parts.splice(-2, 1); // digest is always 2nd to last
-      var headers = { location: { value: `${EXPIRED_REDIRECT_PREFIX}/${parts.join('/')}` } };
+      var value = `${EXPIRED_REDIRECT_PREFIX}/${parts.join('/')}`;
+
+      // preserve token auth, for private feed enclosures
+      if (querystring.auth && querystring.auth.value) {
+        value += `?auth=${querystring.auth.value}`;
+      }
+
+      var headers = { location: { value } };
       return { headers, statusCode: 302, statusDescription: 'Arrangement expired' };
     }
   }

--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ function handler(event) {
     return request;
   }
 
-  // paths can optionally start with a region name, for logging purposes. but
-  // we can just remove it here.
+  // paths can optionally start with an extra string token, specifying which
+  // CloudFront Behavior/Realtime-logs to use. must start with a character.
   var parts = uri.split('/').filter(p => p);
-  if (parts[0].match(/^[a-z]{2}-[a-z\-]+-[0-9]{1}$/)) {
+  if (parts[0].match(/^[a-z][a-z0-9\-]+$/)) {
     parts.shift();
   }
 

--- a/index.js
+++ b/index.js
@@ -9,10 +9,16 @@ function handler(event) {
     return request;
   }
 
+  // paths can optionally start with a region name, for logging purposes. but
+  // we can just remove it here.
+  var parts = uri.split('/').filter(p => p);
+  if (parts[0].match(/^[a-z]{2}-[a-z\-]+-[0-9]{1}$/)) {
+    parts.shift();
+  }
+
   // just kick out invalid looking paths
   // either: /podcast_id/episode_guid/digest/filename.mp3
   //     or: /podcast_id/feed_id/episode_guid/digest/filename.mp3
-  var parts = uri.split('/').filter(p => p);
   if (parts.length !== 4 && parts.length !== 5) {
     return { statusCode: 404, statusDescription: 'Not found. Like, ever.' };
   }

--- a/index.test.js
+++ b/index.test.js
@@ -37,6 +37,12 @@ describe('handler', () => {
 
     const event2 = event('/1234/adfree/some-guid/some-digest/file.mp3');
     expect(handler(event2)).toEqual(event2.request);
+
+    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3');
+    expect(handler(event3)).toEqual(event3.request);
+
+    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3');
+    expect(handler(event4)).toEqual(event4.request);
   });
 
   it('allows non-expired links through', async () => {
@@ -47,6 +53,12 @@ describe('handler', () => {
 
     const event2 = event('/1234/adfree/some-guid/some-digest/file.mp3', { exp });
     expect(handler(event2)).toEqual(event2.request);
+
+    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3', { exp });
+    expect(handler(event3)).toEqual(event3.request);
+
+    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3', { exp });
+    expect(handler(event4)).toEqual(event4.request);
   });
 
   it('redirects expired links', async () => {
@@ -63,9 +75,21 @@ describe('handler', () => {
     expect(handler(event2).headers.location.value).toEqual(
       'https://dovetail.test/1234/adfree/some-guid/file.mp3',
     );
+
+    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3', { exp });
+    expect(handler(event3).statusCode).toEqual(302);
+    expect(handler(event3).headers.location.value).toEqual(
+      'https://dovetail.test/1234/some-guid/file.mp3',
+    );
+
+    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3', { exp });
+    expect(handler(event4).statusCode).toEqual(302);
+    expect(handler(event4).headers.location.value).toEqual(
+      'https://dovetail.test/1234/adfree/some-guid/file.mp3',
+    );
   });
 
-  it('removes filenames and feed-ids from uris', async () => {
+  it('removes filenames, feed-ids, and regions from uris', async () => {
     const exp = { value: now + 10 };
 
     const event1 = event('/1234/some-guid/some-digest/file.mp3', { exp });
@@ -75,6 +99,14 @@ describe('handler', () => {
     const event2 = event('/1234/adfree/some-guid/some-digest/file.mp3', { exp });
     const result2 = handler(JSON.parse(JSON.stringify(event2)));
     expect(result2.uri).toEqual('/1234/some-guid/some-digest');
+
+    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3', { exp });
+    const result3 = handler(JSON.parse(JSON.stringify(event3)));
+    expect(result3.uri).toEqual('/1234/some-guid/some-digest');
+
+    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3', { exp });
+    const result4 = handler(JSON.parse(JSON.stringify(event4)));
+    expect(result4.uri).toEqual('/1234/some-guid/some-digest');
   });
 
   it('forces cache-misses and restitching the arrangement', async () => {

--- a/index.test.js
+++ b/index.test.js
@@ -89,6 +89,17 @@ describe('handler', () => {
     );
   });
 
+  it('preserves auth on expired links', async () => {
+    const exp = { value: now - 10 };
+    const auth = { value: 'my-auth-token' };
+
+    const event1 = event('/1234/adfree/some-guid/some-digest/file.mp3', { exp, auth });
+    expect(handler(event1).statusCode).toEqual(302);
+    expect(handler(event1).headers.location.value).toEqual(
+      'https://dovetail.test/1234/adfree/some-guid/file.mp3?auth=my-auth-token',
+    );
+  });
+
   it('removes filenames, feed-ids, and regions from uris', async () => {
     const exp = { value: now + 10 };
 

--- a/index.test.js
+++ b/index.test.js
@@ -38,10 +38,10 @@ describe('handler', () => {
     const event2 = event('/1234/adfree/some-guid/some-digest/file.mp3');
     expect(handler(event2)).toEqual(event2.request);
 
-    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3');
+    const event3 = event('/use1-whatev/1234/some-guid/some-digest/file.mp3');
     expect(handler(event3)).toEqual(event3.request);
 
-    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3');
+    const event4 = event('/use1-whatev/1234/adfree/some-guid/some-digest/file.mp3');
     expect(handler(event4)).toEqual(event4.request);
   });
 
@@ -54,10 +54,10 @@ describe('handler', () => {
     const event2 = event('/1234/adfree/some-guid/some-digest/file.mp3', { exp });
     expect(handler(event2)).toEqual(event2.request);
 
-    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3', { exp });
+    const event3 = event('/use1-whatev/1234/some-guid/some-digest/file.mp3', { exp });
     expect(handler(event3)).toEqual(event3.request);
 
-    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3', { exp });
+    const event4 = event('/use1-whatev/1234/adfree/some-guid/some-digest/file.mp3', { exp });
     expect(handler(event4)).toEqual(event4.request);
   });
 
@@ -76,13 +76,13 @@ describe('handler', () => {
       'https://dovetail.test/1234/adfree/some-guid/file.mp3',
     );
 
-    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3', { exp });
+    const event3 = event('/use1-whatev/1234/some-guid/some-digest/file.mp3', { exp });
     expect(handler(event3).statusCode).toEqual(302);
     expect(handler(event3).headers.location.value).toEqual(
       'https://dovetail.test/1234/some-guid/file.mp3',
     );
 
-    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3', { exp });
+    const event4 = event('/use1-whatev/1234/adfree/some-guid/some-digest/file.mp3', { exp });
     expect(handler(event4).statusCode).toEqual(302);
     expect(handler(event4).headers.location.value).toEqual(
       'https://dovetail.test/1234/adfree/some-guid/file.mp3',
@@ -111,11 +111,11 @@ describe('handler', () => {
     const result2 = handler(JSON.parse(JSON.stringify(event2)));
     expect(result2.uri).toEqual('/1234/some-guid/some-digest');
 
-    const event3 = event('/us-east-1/1234/some-guid/some-digest/file.mp3', { exp });
+    const event3 = event('/use1-whatev/1234/some-guid/some-digest/file.mp3', { exp });
     const result3 = handler(JSON.parse(JSON.stringify(event3)));
     expect(result3.uri).toEqual('/1234/some-guid/some-digest');
 
-    const event4 = event('/us-east-1/1234/adfree/some-guid/some-digest/file.mp3', { exp });
+    const event4 = event('/use1-whatev/1234/adfree/some-guid/some-digest/file.mp3', { exp });
     const result4 = handler(JSON.parse(JSON.stringify(event4)));
     expect(result4.uri).toEqual('/1234/some-guid/some-digest');
   });


### PR DESCRIPTION
Allow an optional AWS region `/us-west-2/...` prefix on incoming requests.  If present, this function just strips off that token since it's not needed to do the origin request.  (It's only used to direct realtime logs back to a specific region's dovetail-counts-lambda).