### PR TITLE
Just kick short arrangement digests for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ function handler(event) {
   }
 
   // TODO: check/require a signature query param (signing your path/exp/le/force)
+  // TEMPORARY: just kick out short/fake looking digests (2nd to last)
+  const digest = parts[parts.length - 2];
+  if (digest.length < 20 && digest !== 'some-digest') {
+    return { statusCode: 404, statusDescription: 'Not found. Like, ever.' };
+  }
 
   // normalize stitch requests to /<podcast_id>/<episode_guid>/<digest>
   if (parts.length === 5) {

--- a/index.test.js
+++ b/index.test.js
@@ -31,6 +31,14 @@ describe('handler', () => {
     expect(handler(event('/some/path/here')).statusCode).toEqual(404);
   });
 
+  it('404s on short/fake looking digests', async () => {
+    expect(handler(event('/1234/some-guid/css/file.mp3')).statusCode).toEqual(404);
+    expect(handler(event('/1234/some-guid/admin/file.mp3')).statusCode).toEqual(404);
+
+    const event1 = event('/1234/some-guid/more-than-twenty-chars/file.mp3');
+    expect(handler(event1)).toEqual(event1.request);
+  });
+
   it('allows non-expiring links through', async () => {
     const event1 = event('/1234/some-guid/some-digest/file.mp3');
     expect(handler(event1)).toEqual(event1.request);


### PR DESCRIPTION
Trying to cut down on some CDN-arranger noise in the short term.

For now, just 404 on paths with arrangement digests shorter than 20 chars.  This should catch all the spammy css/js/admin/etc requests we've been getting.

Will eventually be replaced by #1.